### PR TITLE
Fix failure to load response from WordPress app - CORS

### DIFF
--- a/frontEnd/src/client/wpLocation.js
+++ b/frontEnd/src/client/wpLocation.js
@@ -1,3 +1,3 @@
 module.exports = {
-  url: 'https://chris-vita-portfolio-wp.herokuapp.com/wp-json/wp/v2'
+  url: 'https://cv-wp-api.herokuapp.com/wp-json/wp/v2'
 };


### PR DESCRIPTION
**Problem:** An intermittent CORS issue, which prevents this app from loading the JSON responses from my separate [WordPress app](https://chris-vita-portfolio-wp.herokuapp.com). (See screenshot below.)

**Potential solution:** I have prepared a fresh install of WP as a new Heroku app, [here](https://cv-wp-api.herokuapp.com), and activated the _HTTP Headers_ plugin with _Access-Control-Allow-Origin_ for this app's origin: https://www.chrisvita.com

<img width="773" alt="screen shot 2017-11-06 at 4 57 42 pm" src="https://user-images.githubusercontent.com/17498763/32517583-b8029308-c3bb-11e7-8053-24ed853f5eaf.png"> While the CORS issue is understandable, I'm confused why it only appears intermittently. The issue seems to be related to the WP cache, as performing ````$ heroku run wp cache flush```` on the WP app temporarily fixes the issue.