### PR TITLE
Fix broken styles on Safari

### DIFF
--- a/frontEnd/public/index.html
+++ b/frontEnd/public/index.html
@@ -22,8 +22,7 @@
     -->
   <link rel="preload" as="image" href='https://cvportoliobucket.s3.amazonaws.com/uploads/2017/11/hero.jpg' alt='hero'>
 
-  <link id="styleSheetBootstrap" rel="preload" as="style" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css"
-    onload="this.rel='stylesheet'">
+  <link id="styleSheetBootstrap" rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" crossorigin="anonymous">
 
   <link rel="preload" as="font" href="https://fonts.googleapis.com/css?family=Droid+Serif:400,700" onload="this.rel='stylesheet'">
 


### PR DESCRIPTION
Issue: On Safari, the Bootstrap CDN was not being utilized as a stylesheet after downloading.